### PR TITLE
[서유림] Feat: input/textarea 컴포넌트 구현

### DIFF
--- a/components/Common/Input/Input.js
+++ b/components/Common/Input/Input.js
@@ -1,0 +1,52 @@
+import { useState } from "react";
+import styles from "./Input.module.css";
+import Image from "next/image";
+import ic_visible from "@/public/assets/icon_visible.svg";
+import ic_inVisible from "@/public/assets/icon_invisible.svg";
+
+export default function Input({ label, type, name, value, onChange, placeholder }) {
+  const [isPasswordVisible, setIsPasswordVisible] = useState(false);
+
+  const togglePasswordVisibility = () => {
+    setIsPasswordVisible((prev) => !prev);
+  };
+
+  const inputType =
+    type === "textarea" ? (
+      <textarea name={name} id={name} value={value} onChange={onChange} placeholder={placeholder} />
+    ) : type === "password" ? (
+      <div className={styles.password}>
+        <input
+          type={isPasswordVisible ? "text" : "password"}
+          name={name}
+          id={name}
+          value={value}
+          onChange={onChange}
+          placeholder={placeholder}
+        />
+        <Image
+          src={isPasswordVisible ? ic_visible : ic_inVisible}
+          onClick={togglePasswordVisibility}
+          width={24}
+          height={24}
+          alt={isPasswordVisible ? "비밀번호 표시" : "비밀번호 숨기기"}
+        />
+      </div>
+    ) : (
+      <input
+        type={type}
+        name={name}
+        id={name}
+        value={value}
+        onChange={onChange}
+        placeholder={placeholder}
+      />
+    );
+
+  return (
+    <div className={styles.group}>
+      <label htmlFor={name}>{label}</label>
+      {inputType}
+    </div>
+  );
+}

--- a/components/Common/Input/Input.module.css
+++ b/components/Common/Input/Input.module.css
@@ -1,0 +1,73 @@
+.group {
+    display: flex;
+    flex-direction: column;
+
+    max-width: 52rem;
+    width: 100%;
+
+    gap: 1rem;
+}
+
+.group label {
+    font-size: 2rem;
+    font-weight: 700;
+    line-height: 2.896rem;
+}
+
+.group input {
+    width: 100%;
+    height: 6rem;
+
+    padding: 1.8rem 2rem;
+    border: 0.1rem solid var(--color-gray-200);
+    border-radius: 0.2rem;
+
+    color: var(--color-white);
+    font-size: 1.6rem;
+    font-weight: 300;
+    line-height: 2.317rem;
+
+    background-color: var(--color-black);
+}
+
+.group input::placeholder,
+.group textarea::placeholder {
+    color: var(--color-gray-200);
+}
+
+.group input:focus,
+.group textarea:focus {
+    outline: 0.1rem solid var(--color-main);
+}
+
+.group textarea {
+    width: 100%;
+    height: 18rem;
+
+    padding: 1.8rem 2rem;
+    border: 0.1rem solid var(--color-gray-200);
+    border-radius: 0.2rem;
+
+    color: var(--color-white);
+    font-size: 1.6rem;
+    font-weight: 300;
+    line-height: 2.317rem;
+
+    background-color: var(--color-black);
+}
+
+.password {
+    position: relative;
+    display: flex;
+    align-items: center;
+}
+
+.password input {
+    padding-right: 5rem;
+}
+
+.password img {
+    position: absolute;
+    right: 2rem;
+    cursor: pointer;
+}


### PR DESCRIPTION
# 수정한 파일
- Input.js / css

# 수정한 목록
- - [x] input / textarea UI 구현
- - [x] 타입별로 인풋 박스 사용할 수 있도록 구현
- - [x] 비밀번호 표시/숨기기 구현

# 사용 방법
![image](https://github.com/user-attachments/assets/36cafb33-66af-4080-b5b1-ecdff81b79f5)
- 사용하고 싶은 곳에서 위와 같이 데이터를 입력해주면 그 데이터를 통해 인풋 출력 가능
- type이 "textarea" 일 경우 textarea 박스로 나오고, type이 "password"라면 password 박스가 나오고, 그 외는 기본 인풋으로 나오도록 구현하였습니다. 만약 type="text"면 텍스트 타입이고, type="email" 이라면 이메일 타입으로 설정됩니다.

# 스크린샷
### input
![image](https://github.com/user-attachments/assets/f866a31d-f541-4caa-b26a-de68a3a5b76c)

### password
![image](https://github.com/user-attachments/assets/c1976a15-aea9-462c-afcc-721ab4d8a638)

### textarea
![image](https://github.com/user-attachments/assets/11d0eb0b-072d-45fd-9c1e-9ceb57356f59)
