### PR TITLE
[서유림] Feat: 등급 컴포넌트 구현

### DIFF
--- a/components/Common/Grade/Grade.js
+++ b/components/Common/Grade/Grade.js
@@ -1,0 +1,15 @@
+import styles from "./Grade.module.css";
+
+export default function Grade({ grade, detail, quantity, border }) {
+  const gradeClass = styles[`grade_${grade.toLowerCase()}`];
+  const gradeDetail = detail ? styles.grade_detail : "";
+  const borderClass = border ? styles.grade_border : "";
+  const showQuantity = quantity ? `${quantity}장` : "";
+
+  return (
+    <div className={`${styles.grade} ${gradeClass} ${gradeDetail} ${borderClass}`}>
+      <p>{grade}</p>
+      <p>{showQuantity}</p>
+    </div>
+  );
+}

--- a/components/Common/Grade/Grade.module.css
+++ b/components/Common/Grade/Grade.module.css
@@ -1,0 +1,48 @@
+.grade {
+    display: inline-flex;
+    justify-content: center;
+    align-items: center;
+
+    width: auto;
+    height: 4rem;
+
+    padding: 0.8rem 2rem;
+
+    font-size: 1.6rem;
+    font-weight: 300;
+    line-height: 2.317rem;
+
+    gap: 1rem;
+}
+
+.grade_detail {
+    font-size: 2.4rem;
+    font-weight: 700;
+    line-height: 3.475rem;
+
+    gap: 0;
+}
+
+.grade_border {
+    border: 0.1rem solid;
+}
+
+.grade_common {
+    color: var(--color-main);
+    border-color: var(--color-main);
+}
+
+.grade_rare {
+    color: var(--color-blue);
+    border-color: var(--color-blue);
+}
+
+.grade_super-rare {
+    color: var(--color-purple);
+    border-color: var(--color-purple);
+}
+
+.grade_legendary {
+    color: var(--color-pink);
+    border-color: var(--color-pink);
+}


### PR DESCRIPTION
# 수정한 파일
- Grade.js / css

# 수정한 목록
- - [x] 등급별 색상 지정
- - [x] 받아오는 props에 따라 등급 스타일 변경

# 사용 방법
`<Grade grade={RARE} detail={false} quantity={5} border={true} />`
- grade : 필요 등급 작성 (대소문자 상관없음, 어차피 소문자로 변환되기 때문)
- detail : 상세 페이지에서는 글자 스타일이 다르므로 상세 페이지에서 사용 시에는 true로 설정
- quantity : 수량 작성
- border : 테두리 유무 작성
  - 이 중 필요없는 prop은 생략해도 괜찮음. ex) <Grade grade={COMMON} />

# 스크린샷
### 카드에 들어갈 스타일
<img width="50" alt="스크린샷 2024-11-18 오전 11 08 58" src="https://github.com/user-attachments/assets/e743bcc8-99b2-4264-8f3d-c70f764de8b9">

### 상세 페이지에 들어갈 스타일
<img width="68" alt="스크린샷 2024-11-18 오전 11 09 15" src="https://github.com/user-attachments/assets/d3650159-b316-4f98-b586-b23c004cda44">

### 마이갤러리 페이지에 들어갈 스타일
<img width="76" alt="스크린샷 2024-11-18 오전 11 08 07" src="https://github.com/user-attachments/assets/fba50347-5890-4802-808a-a03afabdf186">
