### PR TITLE
[서유림] Fix: 포토카드 데이터 수정

### DIFF
--- a/components/Common/PhotoCard/PhotoCard.js
+++ b/components/Common/PhotoCard/PhotoCard.js
@@ -3,7 +3,8 @@ import Image from "next/image";
 import logo from "@/public/assets/logo.svg";
 import Grade from "../Grade/Grade";
 
-export default function PhotoCard({ data, type = "판매카드" }) {
+export default function PhotoCard({ data, type = "판매카드", exchange }) {
+  const exchangeClass = exchange ? styles.exchange : "";
   const cardType =
     type === "내카드" ? (
       <>
@@ -28,7 +29,7 @@ export default function PhotoCard({ data, type = "판매카드" }) {
                 )}
               </div>
               {/* 수정필요 */}
-              <p className={styles.seller}>{data.seller.nickname}</p>
+              <p className={styles.seller}>판매자</p>
             </div>
           </div>
           <div className={styles.card_line}></div>
@@ -88,7 +89,7 @@ export default function PhotoCard({ data, type = "판매카드" }) {
     );
 
   return (
-    <div className={styles.card_container}>
+    <div className={`${styles.card_container} ${exchangeClass}`}>
       {cardType}
       <div className={styles.logo_wrap}>
         <Image className={styles.logo} src={logo} fill alt="사이트 로고" />

--- a/components/Common/PhotoCard/PhotoCard.js
+++ b/components/Common/PhotoCard/PhotoCard.js
@@ -3,53 +3,96 @@ import Image from "next/image";
 import logo from "@/public/assets/logo.svg";
 import Grade from "../Grade/Grade";
 
-export default function PhotoCard({ card, type = "quantity" }) {
-  const selectType = type === "left";
+export default function PhotoCard({ data, type = "판매카드" }) {
+  const cardType =
+    type === "내카드" ? (
+      <>
+        <div className={styles.img_wrap}>
+          <Image className={styles.img} src={data.image} fill alt="카드 이미지" priority />
+        </div>
+        <div className={styles.card_info}>
+          <div className={styles.card_header}>
+            <h1>{data.name}</h1>
+            <div className={styles.meta_info}>
+              <div className={styles.category}>
+                <Grade grade={data.card.grade} />
+                <p className={styles.vert_line}>|</p>
+                <p className={styles.type}>{data.type[0]}</p>
+                {data.type[1] ? (
+                  <>
+                    <p className={styles.vert_line}>|</p>
+                    <p>{data.type[1]}</p>
+                  </>
+                ) : (
+                  ""
+                )}
+              </div>
+              {/* 수정필요 */}
+              <p className={styles.seller}>{data.seller.nickname}</p>
+            </div>
+          </div>
+          <div className={styles.card_line}></div>
+          <div className={styles.card_price_quantity}>
+            <div className={styles.card_price}>
+              <p className={styles.label}>가격</p>
+              <p className={styles.point}>{data.price}p</p>
+            </div>
+            <div className={styles.card_quantity}>
+              <p className={styles.label}>수량</p>
+              <p className={styles.value}>{data.remainingQuantity}</p>
+            </div>
+          </div>
+        </div>
+      </>
+    ) : (
+      <>
+        <div className={styles.img_wrap}>
+          <Image className={styles.img} src={data.card.image} fill alt="카드 이미지" priority />
+        </div>
+        <div className={styles.card_info}>
+          <div className={styles.card_header}>
+            <h1>{data.card.name}</h1>
+            <div className={styles.meta_info}>
+              <div className={styles.category}>
+                <Grade grade={data.card.grade} />
+                <p className={styles.vert_line}>|</p>
+                <p className={styles.type}>{data.card.type[0]}</p>
+                {data.card.type[1] ? (
+                  <>
+                    <p className={styles.vert_line}>|</p>
+                    <p>{data.card.type[1]}</p>
+                  </>
+                ) : (
+                  ""
+                )}
+              </div>
+              <p className={styles.seller}>{data.seller.nickname}</p>
+            </div>
+          </div>
+          <div className={styles.card_line}></div>
+          <div className={styles.card_price_quantity}>
+            <div className={styles.card_price}>
+              <p className={styles.label}>가격</p>
+              <p className={styles.point}>{data.card.price}p</p>
+            </div>
+            <div className={styles.card_quantity}>
+              <p className={styles.label}>잔여</p>
+              <p className={styles.value}>
+                {data.card.remainingQuantity}
+                <span>/{data.card.totalQuantity}</span>
+              </p>
+            </div>
+          </div>
+        </div>
+      </>
+    );
 
   return (
     <div className={styles.card_container}>
-      <div className={styles.img_wrap}>
-        <Image className={styles.img} src={card.image} fill alt="카드 이미지" />
+      {cardType}
+      <div className={styles.logo_wrap}>
+        <Image className={styles.logo} src={logo} fill alt="사이트 로고" />
       </div>
-      <div className={styles.card_info}>
-        <div className={styles.card_header}>
-          <h1>{card.name}</h1>
-          <div className={styles.meta_info}>
-            <div className={styles.category}>
-              <Grade grade={card.grade} />
-              <p className={styles.vert_line}>|</p>
-              <p className={styles.type}>{card.type[0]}</p>
-              {card.type[1] ? (
-                <>
-                  <p className={styles.vert_line}>|</p>
-                  <p>{card.type[1]}</p>
-                </>
-              ) : (
-                ""
-              )}
-            </div>
-            <p className={styles.seller}>판매자</p>
-          </div>
-        </div>
-        <div className={styles.card_line}></div>
-        <div className={styles.card_price_quantity}>
-          <div className={styles.card_price}>
-            <p className={styles.label}>가격</p>
-            <p className={styles.point}>{card.price}p</p>
-          </div>
-          <div className={styles.card_quantity}>
-            {selectType ? (
-              <p className={styles.label}>잔여</p>
-            ) : (
-              <p className={styles.label}>수량</p>
-            )}
-            <p className={styles.value}>
-              <span>{card.remainingQuantity}</span>/{card.totalQuantity}
-            </p>
-          </div>
-        </div>
-      </div>
-      <Image className={styles.logo} src={logo} width={99} height={18} alt="사이트 로고" priority />
     </div>
   );
 }

--- a/components/Common/PhotoCard/PhotoCard.module.css
+++ b/components/Common/PhotoCard/PhotoCard.module.css
@@ -186,11 +186,7 @@
     line-height: 1.448rem;
   }
 
-  .meta_info .seller {
-    font-size: 1rem;
-    line-height: 1.448rem;
-  }
-
+  .meta_info .seller,
   .label,
   .card_price .point,
   .card_quantity .value,
@@ -201,5 +197,32 @@
 
   .logo {
     display: none;
+  }
+
+  .card_container .exchange .img_wrap {
+    width: 30.2rem;
+    height: 22.6rem;
+  }
+
+  .card_container .exchange .card_header h1 {
+    font-size: 2.2rem;
+    line-height: 3.186rem;
+  }
+
+  .card_container .exchange .category p,
+  .card_container .exchange .meta_info .seller,
+  .card_container .exchange .label,
+  .card_container .exchange .card_price .point {
+    font-size: 1.6rem;
+    line-height: 2.317rem;
+  }
+
+  .card_container .exchange .card_quantity .value {
+    font-size: 1.8rem;
+    line-height: 2.606rem;
+  }
+
+  .card_container .exchange .logo {
+    display: block;
   }
 }

--- a/components/Common/PhotoCard/PhotoCard.module.css
+++ b/components/Common/PhotoCard/PhotoCard.module.css
@@ -122,20 +122,30 @@
 }
 
 .card_quantity .value {
-  color: var(--color-gray-300);
+  color: var(--color-white);
   font-size: 1.8rem;
-  font-weight: 300;
+  font-weight: 400;
   line-height: 2.606rem;
 }
 
 .card_quantity span {
+  color: var(--color-gray-300);
+  font-weight: 300;
+}
 
-  color: var(--color-white);
-  font-weight: 400;
+.logo_wrap {
+  position: relative;
+
+  width: 9.9rem;
+  height: 1.8rem;
+
+  margin: 0 auto;
 }
 
 .logo {
-  margin: 2rem auto 0;
+  object-fit: cover;
+  width: 100%;
+  height: 100%;
 }
 
 /* Tablet Only */

--- a/components/Common/PhotoCard/PhotoCardExchange.js
+++ b/components/Common/PhotoCard/PhotoCardExchange.js
@@ -3,7 +3,7 @@ import Image from "next/image";
 import logo from "@/public/assets/logo.svg";
 import Grade from "../Grade/Grade";
 
-export default function PhotoCardExchange({ type = "buyer" }) {
+export default function PhotoCardExchange({ data, type = "buyer" }) {
   const buttonType = type === "seller";
 
   return (
@@ -13,25 +13,32 @@ export default function PhotoCardExchange({ type = "buyer" }) {
       </div>
       <div className={styles.card_info}>
         <div className={styles.card_header}>
-          <h1>정말 귀여운 피카츄</h1>
+          <h1>{data.name}</h1>
           <div className={styles.meta_info}>
             <div className={styles.category}>
-              <Grade grade="LEGENDARY" />
+              <Grade grade={data.grade} />
               <p className={styles.vert_line}>|</p>
-              <p className={styles.type}>전기</p>
-              <p className={styles.vert_line}>|</p>
+              <p className={styles.type}>{data.type[0]}</p>
+              {data.type[1] ? (
+                <>
+                  <p className={styles.vert_line}>|</p>
+                  <p>{data.type[1]}</p>
+                </>
+              ) : (
+                ""
+              )}
             </div>
             <div className={styles.point_seller}>
               <p className={styles.bought}>
-                <span className={styles.point}>4 P</span> 에 구매
+                <span className={styles.point}>{data.price} P</span> 에 구매
               </p>
-              <p className={styles.seller}>판매자</p>
+              <p className={styles.seller}>{data.seller.nickname}</p>
             </div>
           </div>
         </div>
         <div className={styles.card_line}></div>
         <div className={styles.card_description}>
-          <p>아주 귀여운 피카츄군요, 가지고 싶습니다.</p>
+          <p>{data.exchangeDetails}</p>
         </div>
       </div>
       <div className={styles.buttons}>

--- a/components/MyGallery/MyOwnedCards.js
+++ b/components/MyGallery/MyOwnedCards.js
@@ -2,7 +2,7 @@ import Grade from "../Common/Grade/Grade";
 import styles from "./MyOwnedCards.module.css";
 
 export default function MyOwnedCards() {
-  const grades = ["COMMON", "RARE", "SUPER-RARE", "LEGENDARY"];
+  const grades = ["COMMON", "RARE", "SUPER RARE", "LEGENDARY"];
 
   return (
     <div className={styles.container}>
@@ -11,8 +11,10 @@ export default function MyOwnedCards() {
         <p className={styles.total_count}>(40장)</p>
       </div>
       <div className={styles.grade_count}>
-        {grades.map((grade) => (
-          <Grade grade={grade} quantity={10} border={true} />
+        {grades.map((grade, index) => (
+          <div key={index}>
+            <Grade grade={grade} quantity={10} border={true} />
+          </div>
         ))}
       </div>
     </div>


### PR DESCRIPTION
# 수정한 파일
- PhotoCard.js / css
- PhotoCardExchange.js
- MyOwnedCard.js

# 수정한 목록
- - [x] 포토 카드 데이터 수정 
- - [x] MyOwnedCard에 경고가 떠서 경고 메시지 제거했습니다.
- - [x] 미디어 쿼리 수정

# 참고 사항
- 교환 제시목록 api 완성되면 교환 포토카드 내용 수정할 예정입니다.
- PhotoCard props 변경되었습니다. card -> data, type='seller' 또는 'buyer' 였는데 type='내카드' 또는 '판매카드'로 변경했습니다.
- 기본 값은 '판매 카드'로 설정해서 잔여로 표시할 때 따로 type props는 안주셔도 되고, 수량으로 표시할 때만 type='내카드'로 설정해주시면 될 것 같습니다.
- props에 exchange 추가해서 교환 모달에 사용하실 때는 type='내카드' exchange={true}로 설정해주시면 될 것 같습니다!
