### PR TITLE
[서유림] Feat: 페이지 모바일 수정

### DIFF
--- a/components/Common/CardInfo/MyCardDetail.module.css
+++ b/components/Common/CardInfo/MyCardDetail.module.css
@@ -4,7 +4,7 @@
 
     max-width: 44rem;
     width: 100%;
-    height: 39.7rem;
+    height: 100%;
 
     gap: 3rem;
 }
@@ -96,7 +96,6 @@
 @media (min-width: 744px) and (max-width: 1199px) {
     .container {
         max-width: 34.2rem;
-        height: 36.5rem;
     }
 
     .category {
@@ -133,7 +132,6 @@
 @media (max-width: 743px) {
     .container {
         max-width: 34.5rem;
-        height: 36.5rem;
     }
 
     .category p:not(:first-child),

--- a/components/CreateCard/CreateTitle.js
+++ b/components/CreateCard/CreateTitle.js
@@ -1,8 +1,16 @@
 import styles from "./CreateTitle.module.css";
+import Link from "next/link";
+import Image from "next/image";
+import back from "@/public/assets/icon_back.svg";
 
 export default function CreateTitle() {
   return (
     <div className={styles.container}>
+      <div className={styles.back_icon}>
+        <Link href="/myGallery">
+          <Image src={back} width={22} height={22} alt="뒤로가기 아이콘" />
+        </Link>
+      </div>
       <h1 className={styles.title}>포토카드 생성</h1>
       <div className={styles.line}></div>
     </div>

--- a/components/CreateCard/CreateTitle.module.css
+++ b/components/CreateCard/CreateTitle.module.css
@@ -17,6 +17,10 @@
     border: 0.2rem solid var(--color-gray-100);
 }
 
+.back_icon {
+    display: none;
+}
+
 /* Tablet Only */
 @media (min-width: 744px) and (max-width: 1199px) {
     .title {
@@ -27,8 +31,31 @@
 
 /* Mobile Only */
 @media (max-width: 743px) {
+    .container {
+        flex-direction: row;
+        justify-content: center;
+        align-items: center;
+
+        padding: 2rem 0;
+
+        gap: 0;
+    }
+
     .title {
-        font-size: 2em;
+        font-size: 2rem;
         line-height: 2.048rem;
+    }
+
+    .line {
+        display: none;
+    }
+
+    .back_icon {
+        position: absolute;
+        left: 2rem;
+
+        display: flex;
+        justify-content: center;
+        align-items: center;
     }
 }

--- a/components/MyGallery/MyGalleryTitle.js
+++ b/components/MyGallery/MyGalleryTitle.js
@@ -1,4 +1,7 @@
 import styles from "./MyGalleryTitle.module.css";
+import Link from "next/link";
+import Image from "next/image";
+import back from "@/public/assets/icon_back.svg";
 import { useRouter } from "next/router";
 
 export default function MyGalleryTitle() {
@@ -7,6 +10,11 @@ export default function MyGalleryTitle() {
   return (
     <div className={styles.container}>
       <div className={styles.title_button}>
+        <div className={styles.back_icon}>
+          <Link href="/pocketPlace">
+            <Image src={back} width={22} height={22} alt="뒤로가기 아이콘" />
+          </Link>
+        </div>
         <h1>마이 갤러리</h1>
         <button onClick={() => router.push("/myGallery/create")}>포토카드 생성하기</button>
       </div>

--- a/components/MyGallery/MyGalleryTitle.module.css
+++ b/components/MyGallery/MyGalleryTitle.module.css
@@ -66,7 +66,6 @@
     }
 
     .title_button h1 {
-        display: none;
         font-size: 2em;
         line-height: 2.048rem;
     }

--- a/components/MyGallery/MyGalleryTitle.module.css
+++ b/components/MyGallery/MyGalleryTitle.module.css
@@ -44,6 +44,10 @@
     border: 0.2rem solid var(--color-gray-100);
 }
 
+.back_icon {
+    display: none;
+}
+
 /* Tablet Only */
 @media (min-width: 744px) and (max-width: 1199px) {
     .title_button h1 {
@@ -65,8 +69,13 @@
         display: none;
     }
 
+    .title_button {
+        justify-content: center;
+        padding: 2rem 0;
+    }
+
     .title_button h1 {
-        font-size: 2em;
+        font-size: 2rem;
         line-height: 2.048rem;
     }
 
@@ -81,5 +90,14 @@
         line-height: 2.317rem;
 
         z-index: 1;
+    }
+
+    .back_icon {
+        position: absolute;
+        left: 2rem;
+
+        display: flex;
+        justify-content: center;
+        align-items: center;
     }
 }

--- a/components/MyShop/MyShopTitle.js
+++ b/components/MyShop/MyShopTitle.js
@@ -1,8 +1,16 @@
 import styles from "./MyShopTitle.module.css";
+import Link from "next/link";
+import Image from "next/image";
+import back from "@/public/assets/icon_back.svg";
 
 export default function MyShopTitle() {
   return (
     <div className={styles.container}>
+      <div className={styles.back_icon}>
+        <Link href="/pocketPlace">
+          <Image src={back} width={22} height={22} alt="뒤로가기 아이콘" />
+        </Link>
+      </div>
       <h1 className={styles.title}>나의 판매 포토카드</h1>
       <div className={styles.line}></div>
     </div>

--- a/components/MyShop/MyShopTitle.module.css
+++ b/components/MyShop/MyShopTitle.module.css
@@ -17,6 +17,10 @@
     border: 0.2rem solid var(--color-gray-100);
 }
 
+.back_icon {
+    display: none;
+}
+
 /* Tablet Only */
 @media (min-width: 744px) and (max-width: 1199px) {
     .title {
@@ -27,8 +31,29 @@
 
 /* Mobile Only */
 @media (max-width: 743px) {
+    .container {
+        flex-direction: row;
+        justify-content: center;
+
+        padding: 2rem 0;
+        gap: 0;
+    }
+
     .title {
-        font-size: 2em;
+        font-size: 2rem;
         line-height: 2.048rem;
+    }
+
+    .line {
+        display: none;
+    }
+
+    .back_icon {
+        position: absolute;
+        left: 2rem;
+
+        display: flex;
+        justify-content: center;
+        align-items: center;
     }
 }

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -3,13 +3,17 @@ import { Noto_Sans_KR } from "next/font/google";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import GlobalNavigationBar from "@/lib/gnb/gnb";
 import Head from "next/head";
-import { useState } from "react";
+import { useState, useEffect } from "react";
+import { useRouter } from "next/router";
 
 const noto = Noto_Sans_KR({ subsets: ["latin"] });
 
 const queryClient = new QueryClient();
 
 export default function App({ Component, pageProps }) {
+  const router = useRouter();
+  const [isMobile, setIsMobile] = useState(false);
+
   const [isLoggedIn, setIsLoggedIn] = useState(false); // 로그인 상태 관리
   const points = 1540; // 보유 포인트
   const nickname = "유디"; // 닉네임
@@ -19,6 +23,26 @@ export default function App({ Component, pageProps }) {
     setIsLoggedIn((prev) => !prev); // 로그인 상태 반전
   };
 
+  useEffect(() => {
+    const handleResize = () => {
+      setIsMobile(window.innerWidth <= 743);
+    };
+
+    window.addEventListener("resize", handleResize);
+    handleResize();
+
+    return () => {
+      window.removeEventListener("resize", handleResize);
+    };
+  }, []);
+
+  const isMobilePage =
+    router.asPath === "/myGallery" ||
+    router.asPath === "/myShop" ||
+    router.asPath === "/myGallery/create" ||
+    router.asPath.startsWith("/myGallery/") ||
+    router.asPath.startsWith("/card/");
+
   return (
     <QueryClientProvider client={queryClient}>
       <Head>
@@ -27,13 +51,15 @@ export default function App({ Component, pageProps }) {
       </Head>
 
       <div className={noto.className}>
-        <GlobalNavigationBar
-          isLoggedin={isLoggedIn}
-          setIsLoggedIn={setIsLoggedIn}
-          points={points}
-          nickname={nickname}
-          handleAuthChange={handleAuthChange}
-        />
+        {!(isMobile && isMobilePage) && (
+          <GlobalNavigationBar
+            isLoggedin={isLoggedIn}
+            setIsLoggedIn={setIsLoggedIn}
+            points={points}
+            nickname={nickname}
+            handleAuthChange={handleAuthChange}
+          />
+        )}
         <div className="body_container">
           <Component {...pageProps} />
         </div>

--- a/pages/myGallery/[id]/index.js
+++ b/pages/myGallery/[id]/index.js
@@ -1,5 +1,7 @@
 import styles from "@/styles/MyGalleryDetail.module.css";
+import Link from "next/link";
 import Image from "next/image";
+import back from "@/public/assets/icon_back.svg";
 import MyCardDetail from "@/components/Common/CardInfo/MyCardDetail";
 import { getMyPhotoCard } from "@/lib/api/UserService";
 
@@ -23,6 +25,11 @@ export async function getServerSideProps(context) {
 export default function MyGalleryDetail({ myCard }) {
   return (
     <div className={styles.container}>
+      <div className={styles.back_icon}>
+        <Link href="/myGallery">
+          <Image src={back} width={22} height={22} alt="뒤로가기 아이콘" />
+        </Link>
+      </div>
       <div className={styles.title}>
         <h1>{myCard.name}</h1>
         <div className={styles.line}></div>

--- a/styles/MyGalleryDetail.module.css
+++ b/styles/MyGalleryDetail.module.css
@@ -46,15 +46,8 @@
     height: 100%;
 }
 
-.info {
-    display: flex;
-    justify-content: center;
-    align-items: center;
-
-    width: 30%;
-
-    font-size: 2rem;
-    background-color: var(--color-gray-300);
+.back_icon {
+    display: none;
 }
 
 /* Tablet Only */
@@ -82,6 +75,15 @@
 @media (max-width: 743px) {
     .container {
         max-width: 34.5rem;
+        gap: 2rem;
+    }
+
+    .back_icon {
+        display: flex;
+        justify-content: flex-start;
+        align-items: center;
+
+        padding: 2rem 0;
     }
 
     .title h1 {

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -63,4 +63,8 @@ body {
   body {
     padding: 0 1.5rem;
   }
+
+  .body_container {
+    margin: 0 0 5rem;
+  }
 }


### PR DESCRIPTION
# 수정한 파일
- _app.js
- global.css
- MyGalleryTitle.js / css
- CreateTitle.js / css
- myGallery > [id].js / css
- MyCardDetail.module.css
- MyShopTitle.js / css

# 수정한 목록
- - [x] 특정 페이지의 모바일 사이즈에서 GNB 숨기기
- - [x] 모바일 사이즈에서 위에 여백 삭제
- - [x] 마이갤러리 / 마이갤러리 상세 / 나의 판매 포토카드 / 포토카드 생성하기 페이지 모바일 사이즈에서 타이틀 부분 수정
- - [x] MyCardDetail 높이 조정

# 참고 사항
- 현재 app에서 모바일 사이즈 일 때 GNB 바 사라지는 페이지는 전부 추가해두었습니다. 
   제가 맡은 페이지를 포함해서 신철님이 맡으신 상품 상세 페이지까지도 추가해두었습니다!
- global.css에서 모바일 사이즈 일 때 위에 여백 사라지도록 설정하였습니다. 
   GNB 바 사라지면서 위에 여백이 필요가 없어지기 때문에 그렇게 설정해두었습니다.