### PR TITLE
[김윤서] feat:로그인,회원가입 오류수정

### DIFF
--- a/lib/api/auth.js
+++ b/lib/api/auth.js
@@ -1,5 +1,6 @@
 import axios from "axios";
 
+
 const api = axios.create({
   baseURL: "https://pikapick.onrender.com",
   // "http://localhost:3100",
@@ -9,48 +10,77 @@ const api = axios.create({
 });
 
 // 로컬 스토리지에서 액세스 토큰 가져오기
-api.interceptors.request.use(
-  (config) => {
-    const token = localStorage.getItem("accessToken");
-    if (token) {
-      config.headers.Authorization = `Bearer ${token}`;
+api.interceptors.request.use((config) => {
+  const token = localStorage.getItem('accessToken'); 
+  if (token) {
+    config.headers.Authorization = `Bearer ${token}`; 
+  }
+  return config;
+}, (error) => {
+  return Promise.reject(error);
+});
+
+api.interceptors.response.use(
+  (response) => response,
+  async (error) => {
+    const originalRequest = error.config;
+    
+    if (error.response?.status === 401 && !originalRequest._retry) {
+      originalRequest._retry = true;
+      
+      try {
+        const refreshToken = localStorage.getItem('refreshToken');
+        if (!refreshToken) {
+          localStorage.removeItem('accessToken');
+          localStorage.removeItem('refreshToken');
+          localStorage.removeItem('isLoggedIn');
+          return Promise.reject(error);
+        }
+        
+        const response = await api.post('/auth/token/refresh', {
+          refreshToken: refreshToken
+        });
+        
+        const { accessToken } = response.data;
+        localStorage.setItem('accessToken', accessToken);
+        originalRequest.headers.Authorization = `Bearer ${accessToken}`;
+        return api(originalRequest);
+      
+      } catch (refreshError) {
+        localStorage.removeItem('accessToken');
+        localStorage.removeItem('refreshToken');
+        localStorage.removeItem('isLoggedIn');
+        return Promise.reject(refreshError);
+      }
     }
-    return config;
-  },
-  (error) => {
     return Promise.reject(error);
-  },
+  }
 );
 
-// 회원가입
+// 회원가입 
 export const signup = async (email, password, nickname) => {
   try {
-    const response = await api.post("/auth/signup", {
+    const response = await api.post('/auth/signup', {
       email,
       password,
       nickname,
     });
-    console.log("회원가입 성공:", response.data);
     return response.data;
   } catch (error) {
-    console.error("회원가입 에러:", error.response?.data || error.message);
-    throw error;
+    return null;
   }
 };
 
-// 로그인
+// 로그인 
 export const login = async (email, password) => {
   try {
-    const response = await api.post("/auth/login", {
+    const response = await api.post('/auth/login', {
       email,
       password,
     });
-    console.log("로그인 성공:", response.data);
     return response.data;
   } catch (error) {
-    if (error.response) {
-    }
-    throw error;
+    return null;
   }
 };
 
@@ -58,28 +88,34 @@ export const login = async (email, password) => {
 export const getUserProfile = async () => {
   try {
     const response = await api.get("/user/profile");
-    return response.data; // 프로필 정보 반환
+    return response.data; 
   } catch (error) {
+    if (error.response?.status === 401) {
+      localStorage.removeItem('accessToken');
+      localStorage.removeItem('refreshToken');
+      localStorage.removeItem('isLoggedIn');
+    }
     throw error;
   }
 };
+
 
 // 토큰 재발급
 export const refreshToken = async () => {
+  const refresh = localStorage.getItem('refreshToken');
+  if (!refresh) {
+    throw new Error('No refresh token');
+  }
+  
   try {
-    const response = await api.post("/auth/token/refresh");
+    const response = await api.post('/auth/token/refresh', {
+      refreshToken: refresh
+    });
     return response.data;
   } catch (error) {
-    console.error("토큰 재발급 에러:", error.response?.data || error.message);
+    localStorage.removeItem('accessToken');
+    localStorage.removeItem('refreshToken');
+    localStorage.removeItem('isLoggedIn');
     throw error;
   }
 };
-
-const authApi = {
-  signup,
-  login,
-  getUserProfile,
-  refreshToken,
-};
-
-export default authApi;

--- a/lib/gnb/gnb.js
+++ b/lib/gnb/gnb.js
@@ -3,12 +3,14 @@ import { useState } from "react";
 import { useRouter } from "next/router";
 import Image from "next/image";
 import Link from 'next/link';
+import RandomBoxModal from "@/components/Common/RandomBox/RandomBoxModal";
 import UserDrop from "@/components/Common/Profile/Profile";
 import AlertModals from "@/components/Common/Modal/AlertModals";
 
 import styles from './gnb.module.css';
 
-const GlobalNavigationBar = ({ isLoggedin , setIsLoggedIn , points, nickname, handleAuthChange }) => {
+const GlobalNavigationBar = ({ isLoggedin , setIsLoggedIn , points, nickname, handleAuthChange, accessToken  }) => {
+  const [showRandomBoxModal, setShowRandomBoxModal] = useState(false);
   const [showAlerts, setShowAlerts] = useState(false); 
   const [isOpen, setIsOpen] = useState(false);
   const router = useRouter();
@@ -23,14 +25,11 @@ const GlobalNavigationBar = ({ isLoggedin , setIsLoggedIn , points, nickname, ha
     setIsOpen((prev) => !prev);
   };
 
+  // 추가 알림 데이터
   const notifications = [
     { message: "기며누님이 [RARE | 마자용]을 1장 구매 했습니다.", date: new Date() },
     { message: "예진쓰님이 [COMMON | 파치리스]의 포토카드 교환을 제안했습니다.", date: new Date() },
     { message: "[LEGENDARY | 스이쿤]이 품절되었습니다.", date: new Date() },
-    { message: "[LEGENDARY | 스이쿤]이 품절되었습니다.", date: new Date() },
-    { message: "[LEGENDARY | 스이쿤]이 품절되었습니다.", date: new Date() },
-    { message: "[LEGENDARY | 스이쿤]이 품절되었습니다.", date: new Date() },
-    // 추가 알림 데이터
   ];
 
   return (
@@ -44,8 +43,16 @@ const GlobalNavigationBar = ({ isLoggedin , setIsLoggedIn , points, nickname, ha
 
         {isLoggedin ? ( 
           <>
-            <span className={styles.points}>{Number(points).toLocaleString()} P</span>
-            
+            <span className={styles.points} onClick={() => setShowRandomBoxModal(true)}>
+              {Number(points).toLocaleString()} P
+            </span> 
+            {showRandomBoxModal && (
+              <RandomBoxModal 
+                onClose={() => setShowRandomBoxModal(false)} 
+                accessToken={accessToken} // accessToken 전달
+              />
+            )}
+
             <div className={styles.bellContainer}>
               <Image 
                 src="/assets/icon_alarm.svg" 

--- a/lib/gnb/gnb.module.css
+++ b/lib/gnb/gnb.module.css
@@ -2,7 +2,7 @@
   display: flex;
   justify-content: space-between;
   align-items: center;
-  color: var(--color-black); 
+  color: var(--color-red); 
   margin-top: 0.625rem; 
   margin-bottom: 0.625rem;
   padding: 1rem 2rem;
@@ -40,6 +40,7 @@ cursor: pointer;
 font-family: BR B;
 font-weight: 400;
 line-height: 1.5;
+margin: 0 1.25rem; 
 letter-spacing: -0.03em;
 text-align: left;
 text-underline-position: from-font;

--- a/lib/utils/token.js
+++ b/lib/utils/token.js
@@ -2,10 +2,19 @@ export const setAccessToken = (token) => {
   localStorage.setItem('accessToken', token);
 };
 
+export const setRefreshToken = (token) => {
+  localStorage.setItem('refreshToken', token);
+};
+
 export const getAccessToken = () => {
   return localStorage.getItem('accessToken');
 };
 
-export const removeAccessToken = () => {
+export const getRefreshToken = () => {
+  return localStorage.getItem('refreshToken');
+};
+
+export const removeTokens = () => {
   localStorage.removeItem('accessToken');
+  localStorage.removeItem('refreshToken');
 };

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -21,42 +21,54 @@ export default function App({ Component, pageProps }) {
   const fetchUserProfile = async () => {
     try {
       const profile = await getUserProfile(); 
-      setPoints(profile.point); 
+      setPoints(profile.point);
       setNickname(profile.nickname); 
     } catch (error) {
-      console.error("프로필 조회 실패:", error);
+      handleLogout();
     }
   };
-
+  
   const handleLogin = async () => {
     setIsLoggedIn(true);
     localStorage.setItem('isLoggedIn', 'true'); 
     await fetchUserProfile(); 
   };
-
-   const handleLogout = () => {
+  
+  const handleLogout = () => {
     setIsLoggedIn(false);
-    localStorage.removeItem('isLoggedIn'); 
-   };
-
- useEffect(() => {
-    const storedIsLoggedIn = localStorage.getItem('isLoggedIn') === 'true';
-    setIsLoggedIn(storedIsLoggedIn);
-
-    if (storedIsLoggedIn) {
-      fetchUserProfile(); //로그인 상태일 때 프로필 정보 가져오기
+    setPoints(0);
+    setNickname("");
+    localStorage.removeItem('isLoggedIn');
+    localStorage.removeItem('accessToken');
+  };
+  
+  useEffect(() => {
+    if (typeof window !== 'undefined') {
+      const token = localStorage.getItem('accessToken');
+      const storedIsLoggedIn = localStorage.getItem('isLoggedIn') === 'true';
+  
+      if (token && storedIsLoggedIn) {
+        setIsLoggedIn(true);
+        fetchUserProfile();
+      } else if (!token && storedIsLoggedIn) {
+        handleLogout();
+      }
     }
+  }, []);
 
+  useEffect(() => {
     const handleResize = () => {
       setIsMobile(window.innerWidth <= 743);
     };
 
-    window.addEventListener("resize", handleResize);
-    handleResize();
+    if (typeof window !== 'undefined') {
+      window.addEventListener("resize", handleResize);
+      handleResize();
 
-    return () => {
-      window.removeEventListener("resize", handleResize);
-    };
+      return () => {
+        window.removeEventListener("resize", handleResize);
+      };
+    }
   }, []);
 
   const isMobilePage =
@@ -81,7 +93,7 @@ export default function App({ Component, pageProps }) {
           points={points}
           nickname={nickname}
           handleLogout={handleLogout}
-         /> 
+      /> 
             )}
         <div className="body_container">
           <Component {...pageProps} handleLogin={handleLogin} />

--- a/pages/auth/signup.js
+++ b/pages/auth/signup.js
@@ -15,38 +15,45 @@ export default function Signup() {
     confirmPassword: '',
   });
 
-  const [emailError, setEmailError] = useState('');
-  const [nicknameError, setNicknameError] = useState('');
+  const [errors, setErrors] = useState({});
   const router = useRouter();
 
-    const handleChange = async (e) => {
+    const handleChange = (e) => {
     const { name, value } = e.target;
     setFormData({ ...formData, [name]: value });
-  }
+  };
+
+  const validate = () => {
+    const newErrors = {};
+    if (!/\S+@\S+\.\S+/.test(formData.email)) {
+      newErrors.email = '이메일 형식이 올바르지 않습니다!';
+    }
+    if (formData.password.length < 8) {
+      newErrors.password = '비밀번호를 8자 이상 입력해주세요!';
+    }
+    if (formData.password !== formData.confirmPassword) {
+      newErrors.confirmPassword = '비밀번호가 일치하지 않습니다!';
+    }
+    setErrors(newErrors);
+    return Object.keys(newErrors).length === 0;
+  };
 
   const handleSubmit = async (e) => {
     e.preventDefault();
-    if (formData.password !== formData.confirmPassword) {
-      alert('비밀번호가 일치하지 않습니다.');
-      return;
-    }
-
-    //중복된 데이터 api 요청..?
-    if (!formData.email || !formData.nickname) {
-      alert('모든 칸을 채워주세요!!');
-      return;
-    }
-
-    if (emailError || nicknameError) {
-      alert('중복된 정보가 있습니다. 다시 확인해 주세요.');
-      return;
-    }
+    if (!validate()) return;
 
     try {
       await signup(formData.email, formData.password, formData.nickname);
+      alert('회원가입이 완료되었습니다.\n로그인 페이지로 이동합니다.');
       router.push('/auth/login');
     } catch (error) {
-      alert('회원가입에 실패했습니다. 다시 시도해 주세요.');
+      alert('회원가입에 실패했습니다.\n다시 시도해 주세요.');
+      setFormData({
+        email: '',
+        nickname: '',
+        password: '',
+        confirmPassword: ''
+      });
     }
   };
 
@@ -72,6 +79,7 @@ export default function Signup() {
             onChange={handleChange}
             placeholder="이메일을 입력해 주세요"
           />
+          {errors.email && <div className={styles.errorMessage}>{errors.email}</div>}
           </div>
           <div className={styles.inputContainer}>
           <Input
@@ -83,6 +91,7 @@ export default function Signup() {
             placeholder="닉네임을 입력해 주세요"
           />
           </div>
+          
           <div className={styles.inputContainer}>
             <Input
               label="비밀번호"
@@ -92,7 +101,9 @@ export default function Signup() {
               onChange={handleChange}
               placeholder="8자 이상 입력해 주세요"
             />
+            {errors.password && <div className={styles.errorMessage}>{errors.password}</div>}
           </div>
+
           <div className={styles.inputContainer}>
             <Input
               label="비밀번호 확인"
@@ -102,6 +113,7 @@ export default function Signup() {
               onChange={handleChange}
               placeholder="비밀번호를 한번 더 입력해 주세요"
             />
+            {errors.confirmPassword && <div className={styles.errorMessage}>{errors.confirmPassword}</div>}
           </div>
           
           <button type="submit" className={styles.button}>가입하기</button>

--- a/styles/Login.module.css
+++ b/styles/Login.module.css
@@ -39,6 +39,14 @@
   gap: 1rem;
 }
 
+.errorMessage {
+  color: var(--color-pink); 
+  padding: 0.5rem; 
+  border-radius: 0.5rem; 
+  margin-top: 1.5rem; 
+  font-size: 1.8rem;
+}
+
 .button {
   max-width: 46rem;
   width: 100%;

--- a/styles/Signup.module.css
+++ b/styles/Signup.module.css
@@ -28,6 +28,14 @@
   font-weight: 400;
 }
 
+.errorMessage {
+  color: var(--color-pink); 
+  padding: 0.5rem; 
+  border-radius: 0.5rem; 
+  margin-top: 1.5rem; 
+  font-size: 1.8rem;
+}
+
 .button {
   width: 100%;
   padding: 1rem;


### PR DESCRIPTION
* 변경 사항
로그인과 회원가입 에러가 나도 코드가 보이지 않게 변경했습니다.
회원가입 실패 시 로그인 창으로 넘어가던것을 변경하여, 로그인으로 넘어가지 않고 회원가입 페이지로 새로고침하게 바꾸었습니다.
로그인 실패 시 창이 넘어가지 않고 로그인페이지를 새로고침 하게 바꾸었습니다.
사용자에게 로그인 문제점 (이메일형식틀리거나, 비밀번호 불일치) 등을 인풋 아래에 뜨게 했습니다.
새로고침을 해도 로그인을 풀리지 않게 해놓았던 것을 좀 더 보안하여 리프레시 토큰을 요청을 하게 했습니다,
에러메세지 css를 수정 했습니다.
그 외 자잘한 오류를 해결했습니다 


다른것을 하다가 로그인,회원가입에 문제점을 알게 되어서 수정을 하였습니다...
금요일에 수정했던 부분을 제대로 저장하지 않아, 새로해서 평일에 피드백 받았던 점이 다 적용이 안되어 있을 수도 있습니다.
찾아보겠습니다 죄송합니다..ㅠㅠ

