### PR TITLE
[양가현] Feat: 드롭다운 상호작용 및 soldout 라우터 막기

### DIFF
--- a/components/Common/Dropdown/Sort/Attribute.js
+++ b/components/Common/Dropdown/Sort/Attribute.js
@@ -4,20 +4,18 @@ import icon_up from "@/public/assets/icon_up.svg";
 import icon_down from "@/public/assets/icon_down.svg";
 import { useState, useEffect } from "react";
 
-export default function Attribute({ sortType, reset }) {
-  const [isOpen, setIsOpen] = useState(false);
+export default function Attribute({ sortType, reset, isOpen, onToggle }) {
+
   const [selectValue, setSelectValue] = useState("속성");
 
-  const handleToggle = () => {
-    setIsOpen(!isOpen);
-  };
+
 
   const handleSelect = (value) => {
     setSelectValue(value);
-    setIsOpen(false);
     if (sortType) {
       sortType(value);
     }
+    onToggle();
   };
 
   useEffect(() => {
@@ -27,7 +25,7 @@ export default function Attribute({ sortType, reset }) {
   }, [reset]);
 
   return (
-    <div className={styles.dropDown_container} onClick={handleToggle}>
+    <div className={styles.dropDown_container} onClick={onToggle}>
       <div>{selectValue}</div>
       <div className={styles.downIcon_container}>
         <Image src={isOpen ? icon_up : icon_down} alt="토글아이콘" />

--- a/components/Common/Dropdown/Sort/Rating.js
+++ b/components/Common/Dropdown/Sort/Rating.js
@@ -4,20 +4,16 @@ import icon_up from "@/public/assets/icon_up.svg";
 import icon_down from "@/public/assets/icon_down.svg";
 import { useState, useEffect } from "react";
 
-export default function Rating({ sortType, reset }) {
-  const [isOpen, setIsOpen] = useState(false);
+export default function Rating({ sortType, reset, isOpen, onToggle }) {
   const [selectValue, setSelectValue] = useState("등급");
 
-  const handleToggle = () => {
-    setIsOpen(!isOpen);
-  };
 
   const handleSelect = (value) => {
     setSelectValue(value);
-    setIsOpen(false);
     if (sortType) {
       sortType(value);
     }
+    onToggle();
   };
 
   useEffect(() => {
@@ -27,7 +23,7 @@ export default function Rating({ sortType, reset }) {
   }, [reset]);
 
   return (
-    <div className={styles.dropDown_container} onClick={handleToggle}>
+    <div className={styles.dropDown_container} onClick={onToggle}>
       <div>{selectValue}</div>
       <div className={styles.downIcon_container}>
         <Image src={isOpen ? icon_up : icon_down} alt="토글아이콘" />

--- a/components/Common/Dropdown/Sort/Sale.js
+++ b/components/Common/Dropdown/Sort/Sale.js
@@ -4,20 +4,15 @@ import icon_up from "@/public/assets/icon_up.svg";
 import icon_down from "@/public/assets/icon_down.svg";
 import { useState, useEffect } from "react";
 
-export default function Sale({ sortType, reset }) {
-  const [isOpen, setIsOpen] = useState(false);
+export default function Sale({ sortType, reset, isOpen, onToggle }) {
   const [selectValue, setSelectValue] = useState("판매방법");
-
-  const handleToggle = () => {
-    setIsOpen(!isOpen);
-  };
 
   const handleSelect = (value) => {
     setSelectValue(value);
-    setIsOpen(false);
     if (sortType) {
       sortType(value);
     }
+    onToggle();
   };
 
   useEffect(() => {
@@ -29,7 +24,7 @@ export default function Sale({ sortType, reset }) {
   return (
     <div
       className={`${styles.dropDown_container} ${styles.container_large}`}
-      onClick={handleToggle}
+      onClick={onToggle}
     >
       <div>{selectValue}</div>
       <div className={styles.downIcon_container}>

--- a/components/Common/Dropdown/Sort/Soldout.js
+++ b/components/Common/Dropdown/Sort/Soldout.js
@@ -5,23 +5,18 @@ import icon_down from "@/public/assets/icon_down.svg";
 import { useState, useEffect } from "react";
 import { useRouter } from 'next/router';
 
-export default function Soldout({ sortType, reset }) {
-  const [isOpen, setIsOpen] = useState(false);
+export default function Soldout({ sortType, reset, isOpen, onToggle }) {
   const [selectValue, setSelectValue] = useState("매진여부");
 
   const router = useRouter();
 
-  const handleToggle = () => {
-    setIsOpen(!isOpen);
-  };
-
   const handleSelect = (value) => {
     setSelectValue(value);
-    setIsOpen(false);
     if (sortType) {
       const availableValue = value === "잔여" ? true : value === "매진" ? false : undefined;
       sortType(availableValue);
     }
+    onToggle();
   };
 
   useEffect(() => {
@@ -37,7 +32,7 @@ export default function Soldout({ sortType, reset }) {
   return (
     <div
       className={`${styles.dropDown_container} ${styles.container_large}`}
-      onClick={handleToggle}
+      onClick={onToggle}
     >
       <div>{selectValue}</div>
       <div className={styles.downIcon_container}>

--- a/components/Common/Dropdown/Sort/Sort.js
+++ b/components/Common/Dropdown/Sort/Sort.js
@@ -16,8 +16,6 @@ export default function Sort({ sortType, initSort = "낮은 가격순" }) {
     setSelectValue(initSort);
   }, [initSort]);
 
-  /* TODO
-   *sortType 함수 -> 부모 컴포넌트에서 정렬하는 함수를 정의해야함 */
   const handleSelect = (value) => {
     setSelectValue(value);
     setIsOpen(false);

--- a/components/Common/Dropdown/Sort/Sort.module.css
+++ b/components/Common/Dropdown/Sort/Sort.module.css
@@ -8,6 +8,7 @@
   position: relative;
   user-select: none;
   font-weight: 700;
+  cursor: pointer;
 }
 
 .container_large {
@@ -72,6 +73,7 @@
   .dropDown_container {
     font-size: 1.4rem;
   }
+
   .wrapper_box {
     width: 14rem;
   }

--- a/components/PocketPlace/PocketPlaceFilter.js
+++ b/components/PocketPlace/PocketPlaceFilter.js
@@ -11,6 +11,7 @@ import { useState } from "react";
 
 export default function PocketPlaceFilter({ onSearch, onFilterChange, filterCounts }) {
   const [reset, setReset] = useState(false);
+  const [openDropdown, setOpenDropdown] = useState(null);
 
   const handleSearch = (term) => {
     onSearch(term);
@@ -21,12 +22,16 @@ export default function PocketPlaceFilter({ onSearch, onFilterChange, filterCoun
     onFilterChange(filterType, value);
   };
 
+  const handleDropdownToggle = (dropdownName) => {
+    setOpenDropdown(openDropdown === dropdownName ? null : dropdownName);
+  };
+
   const handleResetFilters = () => {
     setReset(true);
-  onFilterChange("type", null);
-  onFilterChange("grade", null);
-  onFilterChange("available", null);
-  onFilterChange("orderBy", "priceLowest");
+    onFilterChange("type", null);
+    onFilterChange("grade", null);
+    onFilterChange("available", null);
+    onFilterChange("orderBy", "priceLowest");
   };
 
   return (
@@ -39,13 +44,22 @@ export default function PocketPlaceFilter({ onSearch, onFilterChange, filterCoun
           <div className={styles.line}></div>
           <div className={styles.filters}>
             <div className={`${styles.desktopOnly} ${styles.rating}`}>
-              <Rating sortType={(value) => handleFilterChange("grade", value)} reset={reset} />
+              <Rating sortType={(value) => handleFilterChange("grade", value)}
+                reset={reset}
+                isOpen={openDropdown === 'grade'}
+                onToggle={() => handleDropdownToggle('grade')} />
             </div>
             <div className={styles.desktopOnly}>
-              <Attribute sortType={(value) => handleFilterChange("type", value)} reset={reset} />
+              <Attribute sortType={(value) => handleFilterChange("type", value)}
+                reset={reset}
+                isOpen={openDropdown === 'type'}
+                onToggle={() => handleDropdownToggle('type')} />
             </div>
             <div className={styles.desktopOnly}>
-              <Soldout sortType={(value) => handleFilterChange("available", value)} reset={reset} />
+              <Soldout sortType={(value) => handleFilterChange("available", value)}
+                reset={reset}
+                isOpen={openDropdown === 'available'}
+                onToggle={() => handleDropdownToggle('available')} />
             </div>
           </div>
           <div className={styles.desktopOnly}>

--- a/components/PocketPlace/PocketPlaceList.js
+++ b/components/PocketPlace/PocketPlaceList.js
@@ -44,7 +44,10 @@ export default function PocketPlaceList({ searchTerm, activeFilter, onFilterCoun
   }, [handleScroll]);
 
   // 로그인 여부 확인
-  const handleCardClick = (cardId) => {
+  const handleCardClick = (cardId, remainingQuantity) => {
+    if (remainingQuantity === 0) {
+      return;
+    }
     const accessToken = localStorage.getItem("accessToken");
     if (!accessToken) {
       setShowNotification(true);
@@ -192,8 +195,9 @@ export default function PocketPlaceList({ searchTerm, activeFilter, onFilterCoun
       {filteredCards.map((item) => (
         <div
           key={item.listId}
-          className={styles.card_wrapper}
-          onClick={() => handleCardClick(item.listId)}
+          className={`${styles.card_wrapper} ${item.card.remainingQuantity === 0 ? styles.disabled : ""
+            }`}
+          onClick={() => handleCardClick(item.listId, item.card.remainingQuantity)}
         >
           <PhotoCard
             data={{

--- a/components/PocketPlace/PocketPlaceList.js
+++ b/components/PocketPlace/PocketPlaceList.js
@@ -13,8 +13,6 @@ export default function PocketPlaceList({ searchTerm, activeFilter, onFilterCoun
   const [currentPage, setCurrentPage] = useState(1);
   const [loading, setLoading] = useState(false);
   const [showNotification, setShowNotification] = useState(false);
-  const [gradeCounts, setGradeCounts] = useState({});
-  const [typeCounts, setTypeCounts] = useState({});
   const isFetching = useRef(false);
 
   const router = useRouter();
@@ -44,7 +42,7 @@ export default function PocketPlaceList({ searchTerm, activeFilter, onFilterCoun
   }, [handleScroll]);
 
   // 로그인 여부 확인
-  const handleCardClick = (cardId, remainingQuantity) => {
+  const handleCardClick = (cardId) => {
     if (remainingQuantity === 0) {
       return;
     }

--- a/components/PocketPlace/PocketPlaceList.module.css
+++ b/components/PocketPlace/PocketPlaceList.module.css
@@ -3,6 +3,7 @@
   grid-template-columns: repeat(3, 1fr);
   gap: 5rem;
 }
+
 .card_wrapper {
   cursor: pointer;
 }
@@ -23,6 +24,10 @@
 
 .row::-webkit-scrollbar-thumb:hover {
   background-color: var(--color-gray-300);
+}
+
+.disabled {
+  cursor: not-allowed;
 }
 
 @media (min-width: 744px) and (max-width: 1199px) {

--- a/pages/myGallery/index.js
+++ b/pages/myGallery/index.js
@@ -31,6 +31,11 @@ export default function MyGallery() {
   const [hasMore, setHasMore] = useState(true);
 
   const [profile, setProfile] = useState({});
+  const [openDropdown, setOpenDropdown] = useState(null);
+
+  const handleDropdownToggle = (dropdownName) => {
+    setOpenDropdown(openDropdown === dropdownName ? null : dropdownName);
+  };
 
   useEffect(() => {
     const fetchData = async () => {
@@ -202,14 +207,22 @@ export default function MyGallery() {
               <SearchBar onSearch={handleSearch} />
             </div>
             <div className={styles.filters}>
-              <Rating sortType={handleGradeFilter} reset={gradeReset} />
-              <Attribute sortType={handleTypeFilter} reset={typeReset} />
+              <Rating sortType={handleGradeFilter}
+                reset={gradeReset}
+                isOpen={openDropdown === 'grade'}
+                onToggle={() => handleDropdownToggle('grade')} />
+              <Attribute
+                sortType={handleTypeFilter}
+                reset={typeReset}
+                isOpen={openDropdown === 'type'}
+                onToggle={() => handleDropdownToggle('type')} />
               <Image
                 src={resetIcon}
                 width={24}
                 height={24}
                 onClick={handleFilterReset}
                 alt="리셋 아이콘"
+                className={styles.refreshIcon}
               />
             </div>
           </div>

--- a/styles/MyGallery.module.css
+++ b/styles/MyGallery.module.css
@@ -51,6 +51,10 @@
     display: none;
 }
 
+.refreshIcon {
+    cursor: pointer;
+}
+
 /* Tablet Only */
 @media (min-width: 744px) and (max-width: 1199px) {
     .search_filters {


### PR DESCRIPTION
## 수정한 파일
- components/Common/Dropdown/Sort/ 안에 있는 파일들
- PocketPlaceFilter.js
- PocketPlaceList.js
- pages/myGallery/index.js

## 수정한 내용
- components/Common/Dropdown/Sort/ 안에 있는 파일들 :: 부모컴포넌트에서 동작하도록 open 없앰
- PocketPlaceFilter.js : 드롭다운 하나만 열리도록
- PocketPlaceList.js : soldout 일 때 상세페이지도 가는 것들을 막음
- pages/myGallery/index.js : 드롭다운 하나만 열리도록

+++ module.css는 대부분 cursor와 관련된 내용들입니다.

---

https://github.com/user-attachments/assets/3f87c26c-fff9-415c-913f-d5cc601e9cec

이미지 깨지는 건 run dev를 안하고 캡처를 해서 그렇게 보입니다..ㅎ 정렬도 잘 작동합니다.

